### PR TITLE
Add test vectors to demonstrate kerlissions

### DIFF
--- a/javascript/test/collide.js
+++ b/javascript/test/collide.js
@@ -1,0 +1,33 @@
+var chai = require('chai');
+var assert = chai.assert;
+var Converter = require('../converter');
+var Kerl = require('../kerl');
+
+describe('kerlission', function() {
+    var tests = [{
+        input: 'GYOMKVTSNHVJNCNFBBAH9AAMXLPLLLROQY99QN9DLSJUHDPBLCFFAIQXZA9BKMBJCYSFHFPXAHDWZFEIZ',
+        expected: 'OXJCNFHUNAHWDLKKPELTBFUCVW9KLXKOGWERKTJXQMXTKFKNWNNXYD9DMJJABSEIONOSJTTEVKVDQEWTW'
+    },{
+        input: 'GYOMKVTSNHVJNCNFBBAH9AAMXLPLLLROQY99QN9DLSJUHDPBLCFFAIQXZA9BKMBJCYSFHFPXAHDWZFEIH',
+        expected: 'OXJCNFHUNAHWDLKKPELTBFUCVW9KLXKOGWERKTJXQMXTKFKNWNNXYD9DMJJABSEIONOSJTTEVKVDQEWTW'
+    },{
+        input: 'GYOMKVTSNHVJNCNFBBAH9AAMXLPLLLROQY99QN9DLSJUHDPBLCFFAIQXZA9BKMBJCYSFHFPXAHDWZFEIQ',
+        expected: 'OXJCNFHUNAHWDLKKPELTBFUCVW9KLXKOGWERKTJXQMXTKFKNWNNXYD9DMJJABSEIONOSJTTEVKVDQEWTW'
+    }];
+
+    tests.forEach(function(test){
+
+        it('Should collide: ' + test.expected, function() {
+            var trits = Converter.trits(test.input);
+            var kerl = new Kerl();
+            kerl.initialize();
+            kerl.absorb(trits, 0, trits.length);
+            var hashTrits = [];
+            kerl.squeeze(hashTrits, 0, kerl.HASH_LENGTH);
+            var hash = Converter.trytes(hashTrits);
+            assert.deepEqual(test.expected, hash);
+        });
+
+    });
+
+});

--- a/javascript/test/collide.js
+++ b/javascript/test/collide.js
@@ -4,30 +4,24 @@ var Converter = require('../converter');
 var Kerl = require('../kerl');
 
 describe('kerlission', function() {
-    var tests = [{
-        input: 'GYOMKVTSNHVJNCNFBBAH9AAMXLPLLLROQY99QN9DLSJUHDPBLCFFAIQXZA9BKMBJCYSFHFPXAHDWZFEIZ',
-        expected: 'OXJCNFHUNAHWDLKKPELTBFUCVW9KLXKOGWERKTJXQMXTKFKNWNNXYD9DMJJABSEIONOSJTTEVKVDQEWTW'
-    },{
-        input: 'GYOMKVTSNHVJNCNFBBAH9AAMXLPLLLROQY99QN9DLSJUHDPBLCFFAIQXZA9BKMBJCYSFHFPXAHDWZFEIH',
-        expected: 'OXJCNFHUNAHWDLKKPELTBFUCVW9KLXKOGWERKTJXQMXTKFKNWNNXYD9DMJJABSEIONOSJTTEVKVDQEWTW'
-    },{
-        input: 'GYOMKVTSNHVJNCNFBBAH9AAMXLPLLLROQY99QN9DLSJUHDPBLCFFAIQXZA9BKMBJCYSFHFPXAHDWZFEIQ',
-        expected: 'OXJCNFHUNAHWDLKKPELTBFUCVW9KLXKOGWERKTJXQMXTKFKNWNNXYD9DMJJABSEIONOSJTTEVKVDQEWTW'
-    }];
+    var expected = 'OXJCNFHUNAHWDLKKPELTBFUCVW9KLXKOGWERKTJXQMXTKFKNWNNXYD9DMJJABSEIONOSJTTEVKVDQEWTW';
+    var tests = [
+        'GYOMKVTSNHVJNCNFBBAH9AAMXLPLLLROQY99QN9DLSJUHDPBLCFFAIQXZA9BKMBJCYSFHFPXAHDWZFEIZ',
+        'GYOMKVTSNHVJNCNFBBAH9AAMXLPLLLROQY99QN9DLSJUHDPBLCFFAIQXZA9BKMBJCYSFHFPXAHDWZFEIH',
+        'GYOMKVTSNHVJNCNFBBAH9AAMXLPLLLROQY99QN9DLSJUHDPBLCFFAIQXZA9BKMBJCYSFHFPXAHDWZFEIQ'
+    ];
 
     tests.forEach(function(test){
 
-        it('Should collide: ' + test.expected, function() {
-            var trits = Converter.trits(test.input);
+        it('Should collide: ' + expected, function() {
+            var trits = Converter.trits(test);
             var kerl = new Kerl();
             kerl.initialize();
             kerl.absorb(trits, 0, trits.length);
             var hashTrits = [];
             kerl.squeeze(hashTrits, 0, kerl.HASH_LENGTH);
             var hash = Converter.trytes(hashTrits);
-            assert.deepEqual(test.expected, hash);
+            assert.deepEqual(expected, hash);
         });
-
     });
-
 });


### PR DESCRIPTION
Setting the last trit to `0`--instead of some deterministic padding scheme (e.g. ISO/IEC 7816-4)--means there are three possible inputs that produce the same hash output.

This is technically a collision in Kerl (but not a collision in Keccak-384), but since it's unique to Iota and a direct consequence of a design decision (and therefore expected), and collisions are a (rather [fun](https://soatok.blog/2020/05/05/putting-the-fun-in-hash-function/)) type of vulnerability in cryptographic hash functions, I opted to coin the term "kerlission" instead.

This pull request adds test cases so that anyone auditing your code knows that kerlissions are totally expected.

Full write-up: [Kerlissions in IOTA's Kerl hash function](https://soatok.blog/2020/07/15/kerlissions-trivial-collisions-in-iotas-hash-function-kerl/)